### PR TITLE
Use framework include syntax

### DIFF
--- a/SCSafariPageController/SCSafariZoomedInLayouter.h
+++ b/SCSafariPageController/SCSafariZoomedInLayouter.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 Stefan Ceriu. All rights reserved.
 //
 
-#import "SCPageLayouter.h"
+#import <SCPageViewController/SCPageLayouter.h>
 
 /** A SCPageViewController layouter that lays out pages vertically and fullscreen */
 @interface SCSafariZoomedInLayouter : SCPageLayouter

--- a/SCSafariPageController/SCSafariZoomedOutLayouter.h
+++ b/SCSafariPageController/SCSafariZoomedOutLayouter.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 Stefan Ceriu. All rights reserved.
 //
 
-#import "SCPageLayouterProtocol.h"
+#import <SCPageViewController/SCPageLayouterProtocol.h>
 
 /** A SCPageViewController page layouter that lays out
  * pages vertically and tilts them to an angle based


### PR DESCRIPTION
This change fixes a compiler error when installing the pod with the `use_frameworks!` option.
